### PR TITLE
Update to reflect Hyper v0.4

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -160,7 +160,7 @@ pub struct MockConnector;
 impl NetworkConnector for MockConnector {
     type Stream = MockStream;
 
-    fn connect(&mut self, _host: &str, _port: u16, _scheme: &str) -> io::Result<MockStream> {
+    fn connect(&mut self, _host: &str, _port: u16, _scheme: &str) -> hyper::Result<MockStream> {
         Ok(MockStream::new())
     }
 }
@@ -182,7 +182,7 @@ impl<C, S> NetworkConnector for TeeConnector<C>
     type Stream = TeeStream<<C as NetworkConnector>::Stream>;
 
     fn connect(&mut self, _host: &str, _port: u16, _scheme: &str)
-        -> io::Result<TeeStream<<C as NetworkConnector>::Stream>> {
+        -> hyper::Result<TeeStream<<C as NetworkConnector>::Stream>> {
         match self.connector.connect(_host, _port, _scheme) {
             Ok(s) => {
                 Ok(TeeStream {
@@ -209,7 +209,7 @@ macro_rules! mock_connector (
 
         impl hyper::net::NetworkConnector for $name {
             type Stream = $crate::MockStream;
-            fn connect(&mut self, host: &str, port: u16, scheme: &str) -> ::std::io::Result<$crate::MockStream> {
+            fn connect(&mut self, host: &str, port: u16, scheme: &str) -> $crate::Result<$crate::MockStream> {
                 use std::collections::HashMap;
                 use std::io::Cursor;
                 debug!("MockStream::connect({:?}, {:?}, {:?})", host, port, scheme);
@@ -247,7 +247,7 @@ macro_rules! mock_connector_in_order (
 
         impl hyper::net::NetworkConnector for $name {
             type Stream = $crate::MockStream;
-            fn connect(&mut self, host: &str, port: u16, scheme: &str) -> ::std::io::Result<$crate::MockStream> {
+            fn connect(&mut self, host: &str, port: u16, scheme: &str) -> $crate::Result<$crate::MockStream> {
                 use std::io::Cursor;
                 debug!("MockStream::connect({:?}, {:?}, {:?})", host, port, scheme);
 


### PR DESCRIPTION
Breaking Change was added to Hyper in this commit:
https://github.com/hyperium/hyper/commit/972b3a388ac3af98ba038927c551b92be3a68d62

This commit hopes to mirror those changes into this copy of the mock
functionality.

I think I got everything (at least everything needed to compile :smile:)
