### PR TITLE
fix(hyper-up) works with hyper 0.7

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,6 @@ documentation = "http://byron.github.io/yup-hyper-mock"
 license = "MIT"
 
 [dependencies]
-hyper = ">= 0.6.0"
+hyper = "0.7"
 log = "*"
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,6 +37,7 @@ use std::net::SocketAddr;
 use std::io::{self, Read, Write, Cursor};
 use std::sync::Mutex;
 use std::collections::HashMap;
+use std::time::Duration;
 
 use hyper::net::{NetworkStream, NetworkConnector};
 
@@ -95,6 +96,14 @@ impl<T> NetworkStream for TeeStream<T>
     fn peer_addr(&mut self) -> io::Result<SocketAddr> {
         self.read_write.peer_addr()
     }
+
+    fn set_read_timeout(&self, _: Option<Duration>) -> io::Result<()> {
+        Ok(())
+    }
+
+    fn set_write_timeout(&self, _: Option<Duration>) -> io::Result<()> {
+        Ok(())
+    }
 }
 impl Clone for MockStream {
     fn clone(&self) -> MockStream {
@@ -152,6 +161,14 @@ impl Write for MockStream {
 impl NetworkStream for MockStream {
     fn peer_addr(&mut self) -> io::Result<SocketAddr> {
         Ok("127.0.0.1:1337".parse().unwrap())
+    }
+
+    fn set_read_timeout(&self, _: Option<Duration>) -> io::Result<()> {
+        Ok(())
+    }
+
+    fn set_write_timeout(&self, _: Option<Duration>) -> io::Result<()> {
+        Ok(())
     }
 }
 


### PR DESCRIPTION
Hyper updated to 0.7, and the NetworkStream trait added to required methods for setting read/write timeouts. I implemented them here as noops so that the crate will at least compile with the new hyper. Can you please release a new version with this patch?

Thanks!
