### PR TITLE
Remove struct visibility inside macro definition (E0447)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -224,7 +224,7 @@ macro_rules! mock_connector (
         $($url:expr => $res:expr)*
     }) => (
 
-        pub struct $name($crate::HostToReplyConnector);
+        struct $name($crate::HostToReplyConnector);
 
         impl Default for $name {
             fn default() -> $name {
@@ -277,7 +277,7 @@ macro_rules! mock_connector_in_order (
     ($name:ident {
         $( $res:expr )*
     }) => (
-        pub struct $name($crate::SequentialConnector);
+        struct $name($crate::SequentialConnector);
 
         impl Default for $name {
             fn default() -> $name {


### PR DESCRIPTION
When trying to use `yup-hyper-mock` and specifically the `mock_connector!` macro, I get the following error:

```
<hyper_mock macros>:2:1: 2:55 error: visibility has no effect inside functions [E0447]
<hyper_mock macros>:2 pub struct $ name ( $ crate:: HostToReplyConnector ) ; impl Default for $ name
```

I'm using Rust 1.5 and I tried to dig in deeper when [this particular check](https://github.com/rust-lang/rust/blob/2343a92a908901958c8207d6d0430a2e59ab0a9c/src/librustc_privacy/lib.rs#L1069) was introduced but I assume it was there in Rust 1.4 as well (?). Which version are you using?

Anyways, this PR should solve the problem - but I'm curious why the visibility was there in the first place? (the original `mock_connector!` doesn't have it)
