### PR TITLE
deps(hyper): Upgrade hyper to 0.10

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,5 +11,5 @@ documentation = "http://byron.github.io/yup-hyper-mock"
 license = "MIT"
 
 [dependencies]
-hyper = ">= 0.7"
+hyper = "0.10"
 log = ">= 0.1"


### PR DESCRIPTION
This (hopefully) solves dermesser/yup-oauth2#51 problems, where two different versions of openssl-sys are included, one of which is pulled in by this crate.


I built and ran the tests successfully.