### PR TITLE
Derive Clone

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,7 @@
-//! Contains various utility types and macros useful for testing hyper clients. 
-//! 
+//! Contains various utility types and macros useful for testing hyper clients.
+//!
 //! # Macros
-//! The `mock_connector!` and `mock_connector_in_order!` macros can be used to 
+//! The `mock_connector!` and `mock_connector_in_order!` macros can be used to
 //! feed a client with preset data. That way you can control exactly what it will
 //! see, confining the test-case to its own sandbox that way.
 //!
@@ -10,7 +10,7 @@
 //! integration test goes into its own binary.
 //!
 //! # Usage
-//! 
+//!
 //! Set it up for use in tests in `Cargo.toml`
 //!
 //! ```toml
@@ -18,9 +18,9 @@
 //! yup-hyper-mock = "*"
 //! log = "*"  # log macros are used within yup-hyper-mock
 //! ```
-//! 
+//!
 //! Link it into your `src/(lib.rs|main.rs)`
-//! 
+//!
 //! ```Rust
 //! #[cfg(test)] #[macro_use]
 //! extern crate "yup-hyper-mock" as hyper_mock
@@ -53,6 +53,7 @@ macro_rules! mock_connector (
         $($url:expr => $res:expr)*
     }) => (
 
+        #[derive(Clone)]
         pub struct $name($crate::HostToReplyConnector);
 
         impl Default for $name {
@@ -82,7 +83,7 @@ macro_rules! mock_connector (
 
 /// A `Connect` which provides a single reply stream per host.
 ///
-/// The mapping is done from full host url (e.g. `http://host.name.com`) to the 
+/// The mapping is done from full host url (e.g. `http://host.name.com`) to the
 /// singular reply the host is supposed to make.
 #[derive(Default, Clone)]
 pub struct HostToReplyConnector {
@@ -96,7 +97,7 @@ impl connect::Connect for HostToReplyConnector {
 
     fn connect(&self, dst: connect::Destination) -> Self::Future {
         debug!("HostToReplyConnector::connect({:?})", dst);
-        
+
         let key = format!("{}://{}", dst.scheme(), dst.host());
         // ignore port for now
         match self.m.get(&key) {


### PR DESCRIPTION
I've found it super useful to be able to clone a mock connector.

This has come up when implementing the `hyper::service::NewService` trait; for that I implement my server with an `Arc<Context>` where `Context` contains all state.

The server is parametrised over the connector for (proxied) HTTP client requests; `Server<C> where C: hyper::client::connect::Connect + Sync + 'static, Server<C>`

But for this to work I do a `clone()` on the `Arc<Context>`, so the `Service<C>` must implement `Clone`, therefore the connector must implement `Clone`, therefore the `MockConnector` must implement `Clone`.

Deriving it worked for me. Hope this makes sense!