### PR TITLE
chore: Update to Hyper 0.14 and Tokio 1.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,9 +1,10 @@
 [package]
 name = "yup-hyper-mock"
-version = "4.0.0"
+version = "5.14.0"
 authors = ["Sean McArthur <sean.monstar@gmail.com>",
            "Jonathan Reem <jonathan.reem@gmail.com>",
-           "Sebastian Thiel <byronimo@gmail.com>"]
+           "Sebastian Thiel <byronimo@gmail.com>",
+           "Benjamin Pannell <contact@sierrasoftworks.com>"]
 description = "A utility library for testing clients using hyper"
 repository = "https://github.com/Byron/yup-hyper-mock"
 documentation = "http://byron.github.io/yup-hyper-mock"
@@ -12,12 +13,12 @@ include = ["src/**/*", "Cargo.toml"]
 edition = "2018"
 
 [dependencies]
-hyper = "0.13.1"
+hyper = { version = "0.14", features = ["client", "http1", "runtime", "stream"] }
 log = ">= 0.4"
 futures = "0.3"
-tokio = { version = "0.2", features = ["io-driver", "io-util", "stream"] }
+tokio = { version = "1.0", features = ["io-util"] }
 mio = "0.6"
 
 [dev-dependencies]
 env_logger = "0.7"
-tokio = { version = "0.2", features = ["macros"] }
+tokio = { version = "1.0", features = ["rt", "macros"] }

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,9 @@
+<a name="v5.14.0"></a>
+## v5.14.0 (2020-12-30)
+
+Upgrade to Hyper 0.14 and Tokio 1.0, which will break any dependencies in Tokio 0.2
+environments.
+
 <a name="v3.12.0"></a>
 ## v3.12.0 (2018-06-10)
 

--- a/tests/macros.rs
+++ b/tests/macros.rs
@@ -7,16 +7,16 @@ use futures::stream::TryStreamExt;
 use hyper::{client::Client, header, Body, Response};
 
 mock_connector_in_order! (MockSequential {
-                                  "HTTP/1.1 200 OK\r\n\
-                                 Server: BOGUS\r\n\
-                                 \r\n\
-                                 1"
+"HTTP/1.1 200 OK\r\n\
+Server: BOGUS\r\n\
+\r\n\
+1"
 
-                                 "HTTP/1.1 200 OK\r\n\
-                                 Server: BOGUS\r\n\
-                                 \r\n\
-                                 2"
-                                  });
+"HTTP/1.1 200 OK\r\n\
+Server: BOGUS\r\n\
+\r\n\
+2"
+});
 
 mock_connector!(MockRedirectPolicy {
     "http://127.0.0.1" =>       "HTTP/1.1 301 Redirect\r\n\


### PR DESCRIPTION
This makes the changes necessary to support Hyper 0.14's dependency on Tokio 1.0 (i.e. changes to the `AsyncRead` API). It also bumps the major version of the library to `5.14.0` (in accordance with the contents of the `changelog.md` file - which places the current Hyper version in the minor version component).

If you'd like to see anything changed here, or would prefer a different versioning scheme be followed - please let me know and I'll be happy to make the changes.