### PR TITLE
build(deps): Update to hyper 1.x

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yup-hyper-mock"
-version = "6.0.0"
+version = "8.0.0"
 authors = ["Sean McArthur <sean.monstar@gmail.com>",
            "Jonathan Reem <jonathan.reem@gmail.com>",
            "Sebastian Thiel <byronimo@gmail.com>",
@@ -10,15 +10,17 @@ repository = "https://github.com/Byron/yup-hyper-mock"
 documentation = "http://byron.github.io/yup-hyper-mock"
 license = "MIT"
 include = ["src/**/*", "Cargo.toml"]
-edition = "2018"
+edition = "2021"
 
 [dependencies]
-hyper = { version = "0.14", features = ["client", "http1", "runtime", "stream"] }
+http-body-util = "0.1.0"
+hyper = { version = "1.1", features = ["client", "http1"] }
+hyper-util = { version = "0.1.2", features = ["tokio", "http1", "client-legacy"] }
 log = ">= 0.4"
 futures = "0.3"
-tokio = { version = "1.0", features = ["io-util"] }
-mio = "0.8"
+tokio = { version = "1.35", features = ["io-util"] }
+tower-service = "0.3"
 
 [dev-dependencies]
-env_logger = "0.7"
+env_logger = "0.10"
 tokio = { version = "1.0", features = ["rt", "macros"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,8 +26,7 @@
 //! extern crate "yup-hyper-mock" as hyper_mock
 //! ```
 
-#[macro_use]
-extern crate log;
+use log::debug;
 
 use std::collections::HashMap;
 use std::pin::Pin;
@@ -37,7 +36,8 @@ use std::task::{Context, Poll};
 use futures;
 use futures::lock::Mutex;
 use futures::Future;
-use hyper::{service::Service, Uri};
+use hyper::Uri;
+use tower_service::Service;
 
 mod streams;
 pub use crate::streams::MockPollStream;
@@ -60,7 +60,7 @@ macro_rules! mock_connector (
             }
         }
 
-        impl hyper::service::Service<hyper::Uri> for $name {
+        impl tower_service::Service<hyper::Uri> for $name {
             type Response = $crate::MockPollStream;
             type Error = std::io::Error;
             type Future = std::pin::Pin<Box<dyn std::future::Future<Output = Result<Self::Response, Self::Error>> + Send>>;
@@ -127,7 +127,7 @@ macro_rules! mock_connector_in_order (
             }
         }
 
-        impl hyper::service::Service<hyper::Uri> for $name {
+        impl tower_service::Service<hyper::Uri> for $name {
             type Response = $crate::MockPollStream;
             type Error = std::io::Error;
             type Future = std::pin::Pin<Box<dyn std::future::Future<Output = Result<Self::Response, Self::Error>> + Send>>;


### PR DESCRIPTION
Updates the `hyper` dependency to `1.1`.

[Upgrade guide](https://hyper.rs/guides/1/upgrading/)

Updated README and tests, and bumped the edition to `2021`.

Bumped the version to `8.0.0`

Closes #24 

cc @Byron 